### PR TITLE
Fixed disconnection due to serviceWorker termination

### DIFF
--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -38,7 +38,7 @@ await Promise.all(
           author: packageJson.author,
           homepage_url: packageJson.repository,
 
-          permissions: ['tabs'],
+          permissions: ['tabs', 'storage'],
 
           icons: {
             '16': 'icons/icon-16.png',

--- a/src/background/application.ts
+++ b/src/background/application.ts
@@ -75,7 +75,7 @@ function connect(tabId: number): void {
   }
 }
 
-function keepAlive() {
+function keepAlive(): void {
   const keepAliveIntervalId = setInterval(
     () => {
       if (ws) {
@@ -85,7 +85,7 @@ function keepAlive() {
       }
     },
     // Set the interval to 20 seconds to prevent the service worker from becoming inactive.
-    20 * 1000 
+    20 * 1000,
   );
 }
 

--- a/src/background/application.ts
+++ b/src/background/application.ts
@@ -75,6 +75,20 @@ function connect(tabId: number): void {
   }
 }
 
+function keepAlive() {
+  const keepAliveIntervalId = setInterval(
+    () => {
+      if (ws) {
+        ws.send('keepalive');
+      } else {
+        clearInterval(keepAliveIntervalId);
+      }
+    },
+    // Set the interval to 20 seconds to prevent the service worker from becoming inactive.
+    20 * 1000 
+  );
+}
+
 function send(action: ApplicationMessageAction, payload: any = {}): void {
   ws.send(JSON.stringify({ action, payload }));
 }
@@ -85,6 +99,7 @@ async function handleMessage(message: ExtensionMessage | any, sender: Runtime.Me
   switch (message.action) {
     case ExtensionMessageAction.ConnectApp:
       connect(sender.tab.id);
+      keepAlive();
       break;
     case ExtensionMessageAction.DisconnectApp:
       if (connectedTabId === sender.tab.id) {

--- a/src/background/application.ts
+++ b/src/background/application.ts
@@ -79,7 +79,7 @@ function keepAlive(): void {
   const keepAliveIntervalId = setInterval(
     () => {
       if (ws) {
-        ws.send('keepalive');
+        browser.storage.session.set({ keepAlive: new Date().getTime() });
       } else {
         clearInterval(keepAliveIntervalId);
       }


### PR DESCRIPTION
With manifest v3, the serviceWorkers are much more aggressively terminated. Writing to the WebSocket before the 30s timeout will keep the serviceWorker alive and avoid disconnection with the host app.